### PR TITLE
Fixing sending funds to subaccount

### DIFF
--- a/src/popup/router/pages/Send.vue
+++ b/src/popup/router/pages/Send.vue
@@ -193,7 +193,10 @@ export default {
     },
     openExplorer(url) {
       browser.tabs.create({url,active:false});
-    }
+    },
+    selectSendSubaccount(account) {
+      this.form.address = account.publicKey;
+    }	    
   }
 }
 </script>


### PR DESCRIPTION
The function for sending funds to subaccount was missing after merge and added it again in this pull request. 