### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "waellet",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
After changing version in package.json, the same change must be done in package-lock.json because if the package.json and package-lock.json are different Circle CI build procedure won't run at all